### PR TITLE
Make the chrono dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,16 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "chrono"]
 std = ["clap"]
+chrono = ["dep:chrono"]
 
 [dependencies]
 bytemuck = { version = "1.16.0", features = ["derive"] }
 num-traits = { version = "0.2.19", default-features = false }
 num-derive = "0.4.2"
 bitflags = { version = "2.5.0", default-features = false }
-chrono = { version = "0.4.38", default-features = false }
+chrono = { version = "0.4.38", default-features = false, optional = true }
 clap = { version = "4.5.6", features = ["cargo"], optional = true }
 
 [dev-dependencies]

--- a/src/coff.rs
+++ b/src/coff.rs
@@ -3,7 +3,6 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use bitflags::bitflags;
 use core::{fmt, str};
-use chrono::{DateTime, Utc};
 use crate::prelude::*;
 
 /// COFF File Header (Object and Image)
@@ -34,8 +33,11 @@ impl fmt::Display for CoffFileHeader {
             .expect("Failed to get machine type");
         let characteristics = self.get_characteristics()
             .expect("Failed to get characteristics");
+        #[cfg(feature = "chrono")]
         let time = self.get_time_date_stamp()
             .expect("Failed to get time date stamp");
+        #[cfg(not(feature = "chrono"))]
+        let time = self.time_date_stamp;
 
         writeln!(f, "COFF Header")?;
         writeln!(f, "-----------")?;
@@ -194,7 +196,8 @@ impl CoffFileHeader {
     }
 
     /// Returns the Unix epoch timestamp as a `DateTime<Utc>`
-    pub fn get_time_date_stamp(&self) -> Option<DateTime<Utc>> {
-        DateTime::from_timestamp(self.time_date_stamp.into(), 0)
+    #[cfg(feature = "chrono")]
+    pub fn get_time_date_stamp(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp(self.time_date_stamp.into(), 0)
     }
 }


### PR DESCRIPTION
Move the chrono dependency behind a feature flag. Allows consumers to opt out of the chrono dependency tree if the associated functionality is not required.

The feature flag is enabled by default in order to maintain backwards compatibility.